### PR TITLE
PM-228 Run multiple CMake build configs in CI

### DIFF
--- a/.github/workflows/_build-shared.yml
+++ b/.github/workflows/_build-shared.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set reusable strings
         id: strings
         shell: bash
-        run: echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+        run: echo "build-root-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
       - name: Set up environment
         if: ${{ inputs.setup_env_script }}

--- a/.github/workflows/_build-shared.yml
+++ b/.github/workflows/_build-shared.yml
@@ -15,6 +15,10 @@ on:
       qt_version:
         required: true
         type: string
+      build_types_bash:
+        description: Bash array literal of CMake build configurations to process sequentially.
+        required: true
+        type: string
       qt_arch: # get rid of this, eventually, by detecting the correct Qt architecture based on the OS and compiler-
         description: Qt architecture passed to jurplel/install-qt-action (e.g. clang_64 for macOS Intel).
         required: false
@@ -53,18 +57,42 @@ jobs:
           install-deps: 'true'
           set-env: 'true'
 
-      - name: Configure CMake
-        run: >
-          cmake -B ${{ steps.strings.outputs.build-output-dir }}
-          -DCMAKE_C_COMPILER=${{ inputs.c_compiler }}
-          -DCMAKE_CXX_COMPILER=${{ inputs.cpp_compiler }}
-          -DCMAKE_BUILD_TYPE=Release
-          ${{ steps.strings.outputs.osx_arch_flag }}
-          -S ${{ github.workspace }}
+      - name: Configure requested configurations
+        shell: bash
+        run: |
+          build_types=${{ inputs.build_types_bash }}
 
-      - name: Build
-        run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config Release
+          for build_type in "${build_types[@]}"; do
+            build_dir="${{ steps.strings.outputs.build-root-dir }}/$(printf '%s' "$build_type" | tr '[:upper:]' '[:lower:]')"
 
-      - name: Test
-        working-directory: ${{ steps.strings.outputs.build-output-dir }}
-        run: ctest --build-config Release
+            echo "Configuring ${build_type} in ${build_dir}"
+            cmake -B "$build_dir" \
+              -DCMAKE_C_COMPILER="${{ inputs.c_compiler }}" \
+              -DCMAKE_CXX_COMPILER="${{ inputs.cpp_compiler }}" \
+              -DCMAKE_BUILD_TYPE="$build_type" \
+              -S "${{ github.workspace }}"
+          done
+
+      - name: Build requested configurations
+        shell: bash
+        run: |
+          build_types=${{ inputs.build_types_bash }}
+
+          for build_type in "${build_types[@]}"; do
+            build_dir="${{ steps.strings.outputs.build-root-dir }}/$(printf '%s' "$build_type" | tr '[:upper:]' '[:lower:]')"
+
+            echo "Building ${build_type}"
+            cmake --build "$build_dir" --config "$build_type"
+          done
+
+      - name: Test requested configurations
+        shell: bash
+        run: |
+          build_types=${{ inputs.build_types_bash }}
+
+          for build_type in "${build_types[@]}"; do
+            build_dir="${{ steps.strings.outputs.build-root-dir }}/$(printf '%s' "$build_type" | tr '[:upper:]' '[:lower:]')"
+
+            echo "Testing ${build_type}"
+            ctest --test-dir "$build_dir" --build-config "$build_type"
+          done

--- a/.github/workflows/_matrix-config.yml
+++ b/.github/workflows/_matrix-config.yml
@@ -8,6 +8,9 @@ on:
         # lowest LTS version that we can get through aqt is 5.9, so we start from there
         # that's the reason why "5.6.*" is not included
         value: '["5.9.*", "5.12.*", "5.15.*", "6.2.*", "6.5.*", "6.8.*"]'
+      build_types_bash:
+        description: "Bash array literal of CMake build configurations to process sequentially in each CI job"
+        value: '("Debug" "RelWithDebInfo")'
       compilers_linux:
         description: "Compilers for Linux"
         value: '["gcc", "clang"]'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,3 +38,4 @@ jobs:
       c_compiler: ${{ matrix.c_compiler }}
       cpp_compiler: ${{ matrix.cpp_compiler }}
       qt_version: ${{ matrix.qt_version }}
+      build_types_bash: ${{ needs.get-matrix.outputs.build_types_bash }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -38,6 +38,7 @@ jobs:
       c_compiler: ${{ matrix.c_compiler }}
       cpp_compiler: ${{ matrix.cpp_compiler }}
       qt_version: ${{ matrix.qt_version }}
+      build_types_bash: ${{ needs.get-matrix.outputs.build_types_bash }}
       qt_arch: clang_64  # x86_64 Qt binary for Intel cross-compilation
       setup_env_script: |
         # Install Rosetta 2 so x86_64 test binaries can run on the ARM64 runner.
@@ -69,3 +70,4 @@ jobs:
       c_compiler: ${{ matrix.c_compiler }}
       cpp_compiler: ${{ matrix.cpp_compiler }}
       qt_version: ${{ matrix.qt_version }}
+      build_types_bash: ${{ needs.get-matrix.outputs.build_types_bash }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,3 +40,4 @@ jobs:
       c_compiler: ${{ matrix.c_compiler }}
       cpp_compiler: ${{ matrix.cpp_compiler }}
       qt_version: ${{ matrix.qt_version }}
+      build_types_bash: ${{ needs.get-matrix.outputs.build_types_bash }}


### PR DESCRIPTION
Add support for processing multiple CMake build configurations sequentially in CI. Introduces a build_types_bash input (bash array literal) in the matrix and workflow inputs, and updates the shared build workflow to loop over the requested configurations to run cmake configure, build, and ctest per configuration (creating per-config build dirs, lowercased). Propagates the build_types_bash value into Linux, macOS and Windows job inputs via the get-matrix output.